### PR TITLE
Fix edge ID retrieval

### DIFF
--- a/furniture/DrawerBox.cs
+++ b/furniture/DrawerBox.cs
@@ -126,7 +126,8 @@ namespace furniture
                 if (Math.Abs(start.Z - height) < Tolerance.Global.EqualPoint &&
                     Math.Abs(end.Z - height) < Tolerance.Global.EqualPoint)
                 {
-                    edgeIdList.Add(edge.SubentityId); 
+                    // use the edge's full subentity path to obtain its ID
+                    edgeIdList.Add(edge.SubentityPath.SubentId);
                 }
             }
 


### PR DESCRIPTION
## Summary
- fix retrieval of SubentityId using `SubentityPath.SubentId`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853b3994180832fa0b60cbe42c8fbc5