### PR TITLE
Fix XData loss after editing

### DIFF
--- a/furniture/Features/DrawerBox.cs
+++ b/furniture/Features/DrawerBox.cs
@@ -129,6 +129,9 @@ namespace yz.furniture.Features
                 pline.Dispose();
                 region.Dispose();
                 
+                // 记录实体ID，便于后续关联
+                this.EntityId = solid.ObjectId;
+
                 // 返回新实体的ID
                 return solid.ObjectId;
             }
@@ -188,6 +191,7 @@ namespace yz.furniture.Features
             finally
             {
                 rb.Dispose();
+                obj.Dispose();
             }
 
             return drawerBox;

--- a/furniture/UI/Palettes/PropertyPaletteControl.cs
+++ b/furniture/UI/Palettes/PropertyPaletteControl.cs
@@ -77,6 +77,9 @@ namespace yz.furniture.UI.Palettes
                             
                             DBObject objToUpdate = tr.GetObject(per.ObjectId, OpenMode.ForWrite);
 
+                            // 先清除旧的 XData，避免残留导致解析失败
+                            objToUpdate.XData = null;
+
                             var rb = new ResultBuffer(
                                 new TypedValue((int)DxfCode.ExtendedDataRegAppName, AppName),
                                 new TypedValue((int)DxfCode.ExtendedDataAsciiString, box.ComponentName ?? "未命名部件"),


### PR DESCRIPTION
## Summary
- ensure existing XData is cleared before writing new values
- keep the entity id when creating a drawer box and dispose the db object after reading

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685684bb8f14832fa134a1d72d889bb6